### PR TITLE
Rename package to 'cloudforet_search' (PEP 625 compliance)

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(
-    name="cloudforet-search",
+    name="cloudforet_search",
     version=os.environ.get("PACKAGE_VERSION"),
     description="Cloudforet search service",
     long_description="",


### PR DESCRIPTION
### Category
- [ ] New feature
- [v] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Rename package to 'cloudforet_search' (PEP 625 compliance)
